### PR TITLE
Fix for CASAVA 1.8 read name support

### DIFF
--- a/tag_to_header.py
+++ b/tag_to_header.py
@@ -123,7 +123,7 @@ def hdrRenameFxn(x, y, z):
         # Illumina CASAVA >= 1.8
         #   e.g. @EAS139:136:FC706VJ:2:2104:15343:197393 1:Y:18:ATCACG
         readnum = x.split(" ")[1].split(":")[0]
-        return("%s|%s%s/%s" % (x.replace(' ', '_'), y, z, readnum))
+        return("%s|%s%s/%s" % (x.split(" ")[0].replace(' ', '_'), y, z, readnum))
 
     elif len(illumina) == 5:
         # Illumina CASAVA < 1.8 (and perhaps >= 1.4?)


### PR DESCRIPTION
This fixes commit "Support CASAVA >= 1.8 FastQ headers" (d6729cd).  The
whole read name must not be used since the end will vary between reads
in a pair.  Instead, use the common part before the first space.

The bug manifested as a "paired reads have different names" error from
bwa.
