### PR TITLE
tag_to_header.py: Always write trailing newlines

### DIFF
--- a/tag_to_header.py
+++ b/tag_to_header.py
@@ -85,17 +85,12 @@ class fastQItterator:
 class fastqWriter:
     def __init__(self, outFile):
         self.file=outFile
-        self.firstLine=True
     
     def write(self, read):
-        if self.firstLine==True:
-            self.file.write("@" + read.name)
-            self.firstLine=False
-        else:
-            self.file.write("\n@" + read.name)
-        self.file.write("\n" + read.seq)
-        self.file.write("\n" + read.spacer)
-        self.file.write("\n" + read.qual)
+        self.file.write("@" + read.name + "\n")
+        self.file.write(read.seq + "\n")
+        self.file.write(read.spacer + "\n")
+        self.file.write(read.qual + "\n")
         return(True)
     
     def close(self):


### PR DESCRIPTION
Leaving off a final newline in text files is very unconventional for
Unix and breaks a number of assumptions that other common tools make.
It's also simpler to always write a newline than to keep track of
whether you're writing the first line or not.

For example, obtaining a line count with `wc -l` on the produced FastQ
files will be off by one before this change.
