### PR TITLE
When using sam tags for the duplex sequences, remember to append the …

### DIFF
--- a/ConsensusMaker.py
+++ b/ConsensusMaker.py
@@ -262,7 +262,8 @@ def main():
                 if 0 < len(samtags):
                     tag = "".join([tagtuple[1] for tagtuple in readWin[winPos%2].tags if tagtuple[0] in samtags])
                 else:
-                    tag = readWin[winPos%2].qname.split('|')[1].split('/')[0] + (":1" if readWin[winPos%2].is_read1 == True else (":2" if readWin[winPos%2].is_read2 == True else ":se"))
+                    tag = readWin[winPos%2].qname.split('|')[1].split('/')[0] 
+                tag = tag + (":1" if readWin[winPos%2].is_read1 == True else (":2" if readWin[winPos%2].is_read2 == True else ":se"))
                 tagDict[tag] += 1
             except:
                 print readNum


### PR DESCRIPTION
…read #.

@loeblab it looks like the suffix for the tag was not being appended when using the SAM tags.  I was getting far fewer single-strand consensus sequences when I use the sam tag option versus not.  My apologies for introducing the bug.
