### PR TITLE
The first tag was not being split correctly resulting in all unpaired

### DIFF
--- a/DuplexMaker.py
+++ b/DuplexMaker.py
@@ -135,7 +135,7 @@ def main():
         else:
             # Send reads to DCSMaker
             firstRead = line # Store the present line for the next group of lines
-            firstTag = firstRead.qname
+            firstTag = firstRead.qname.split(":")[0]
             readOne=True
             dictKeys = readDict.keys()
             


### PR DESCRIPTION
reads.

@loeblab I think this is a fairly serious bug if I understand it correctly.  Here are some SAM records on which to test.  Prior to this fix, an unpaired consensus is made.  After this fix, a proper double-strand consensus sequence is made.

```
TGGCGGGAAATGAACAAATCTCTT:1:4    99  1   115250972   255 108M    =   115251247   383 AATCAAATGTTTTAAACACTTTAGACCTCAGTACTTTCAGAAAGGGTGTCATATGGAAAATGTGCAGAAGAGGATAGGCAGAAACTCAAAAAACATATAGACAATAAC    JJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJ
AACAAATCTCTTTGGCGGGAAATG:2:3    163 1   115250972   255 108M    =   115251247   383 AATCAAATGTTTTAAACACTTTAGACCTCAGTACTTTCAGAAAGGGTGTCATATGGAAAATGTGCAGAAGAGGATAGGCAGAAACTCAAAAAACATATAGACAATAAC    JJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJ
TGGCGGGAAATGAACAAATCTCTT:2:4    147 1   115251247   255 108M    =   115250972   -383    ACCAGTGTGTAAAAAGCATCTTCAACACCCTATAAAAGGAAAAAATGAAAAAAAATGAGAGAGCTAGCTCAACGGACACAATCCAAATTATAAGCTCTCTTGCATTTG    JJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJ
AACAAATCTCTTTGGCGGGAAATG:1:3    83  1   115251247   255 108M    =   115250972   -383    ACCAGTGTGTAAAAAGCATCTTCAACACCCTATAAAAGGAAAAAATGAAAAAAAATGAGAGAGCTAGCTCAACGGACACAATCCAAATTATAAGCTCTCTTGCATTTG    JJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJ
```
