### PR TITLE
Revert "The first tag was not being split correctly resulting in all unpaired"

### DIFF
--- a/DuplexMaker.py
+++ b/DuplexMaker.py
@@ -135,7 +135,7 @@ def main():
         else:
             # Send reads to DCSMaker
             firstRead = line # Store the present line for the next group of lines
-            firstTag = firstRead.qname.split(":")[0]
+            firstTag = firstRead.qname
             readOne=True
             dictKeys = readDict.keys()
             


### PR DESCRIPTION
Issue arose that prevented duplexes from being written to file. Reverts loeblab/Duplex-Sequencing#27
