### PR TITLE
Improvements to DuplexMaker and ConsensusMaker.

### DIFF
--- a/ConsensusMaker.py
+++ b/ConsensusMaker.py
@@ -67,7 +67,7 @@ optional arguments:
                         Overlap filter. n: N filter. ['osn']
   --sam_tag SAM_TAG     The SAM tag that store the duplex tag sequence (can 
                         be set one more times).  Otherwise use the sequence 
-                        in the read name."
+                        in the read name.
 
 
 Details of different arguments:
@@ -245,6 +245,7 @@ def main():
 
     readDict = {} # Initialize the read dictionary
     tagDict = defaultdict( lambda: 0 ) # Initialize the tag dictionary
+    outputReadNum = 1
 
     consensusDict={}
 
@@ -381,11 +382,15 @@ def main():
                         altTag=dictTag.replace(("1" if "1" in dictTag else "2"),("2" if "1" in dictTag else "1"))
 
                         if altTag in consensusDict:
+                            a.qname = "%d:%s" % (outputReadNum, a.qname)
+                            b = consensusDict.pop(altTag)
+                            b.qname = "%d:%s" % (outputReadNum, b.qname)
+                            outputReadNum += 1
                             if a.is_read1 == True:
                                 outBam.write(a)
-                                outBam.write(consensusDict.pop(altTag))
+                                outBam.write(b)
                             else:
-                                outBam.write(consensusDict.pop(altTag))
+                                outBam.write(b)
                                 outBam.write(a)
                         else:
                             consensusDict[dictTag]=a
@@ -405,7 +410,10 @@ def main():
             extraBam.write(consensusDict.pop(consTag))
             UP += 1
         else:
-            outBam.write(consensusDict.pop(consTag))
+            b = consensusDict.pop(consTag)
+            b.qname = "%d:%s" % (outputReadNum, b.qname)
+            outputReadNum += 1
+            outBam.write(b)
 
     # Close BAM files
     inBam.close()

--- a/ProgramOptions.html
+++ b/ProgramOptions.html
@@ -94,6 +94,11 @@
     <td width="390" colspan="7" valign="top"><p>Run    alignments in parallel.&nbsp; Not currently    supported.&nbsp; </p></td>
   </tr>
   <tr>
+    <td width="67" valign="top"><p>&nbsp;</p></td>
+    <td width="126" valign="top"><p>--sam_tag</p></td>
+	<td width="390" colspan="7" valign="top"><p>The SAM tag that store the duplex tag sequence (can be set one more times).  Otherwise use the sequence in the read name. </p></td>
+  </tr>
+  <tr>
     <td width="583" colspan="9" valign="top"><p><strong><u>&nbsp;</u></strong></p></td>
   </tr>
   <tr>
@@ -158,7 +163,7 @@
   </tr>
   <tr>
     <td width="67" valign="top"><p><em>Usage: </em></p></td>
-    <td width="516" colspan="8" valign="top"><p>ConsensusMaker.py    --infile INFILE --tagfile TAGFILE --outfile OUTFILE&nbsp; --minmem MINMEM --maxmem MAXMEM --cutoff    CUTOFF --Ncutoff NCUTOFF --readlength READ_LENGTH --read_type READ_TYPE    --filt FILT [--isize ISIZE] [--read_out ROUT] [--rep_filt REP_FILT]</p></td>
+    <td width="516" colspan="8" valign="top"><p>ConsensusMaker.py    --infile INFILE --tagfile TAGFILE --outfile OUTFILE&nbsp; --minmem MINMEM --maxmem MAXMEM --cutoff    CUTOFF --Ncutoff NCUTOFF --readlength READ_LENGTH --read_type READ_TYPE    --filt FILT [--isize ISIZE] [--read_out ROUT] [--rep_filt REP_FILT] [--sam_tag SAM_TAG]</p></td>
   </tr>
   <tr>
     <td width="583" colspan="9" valign="top"><p><em>Required arguments:</em></p></td>
@@ -427,7 +432,7 @@
   </tr>
   <tr>
     <td width="67" valign="top"><p><em>Usage: </em></p></td>
-    <td width="516" colspan="8" valign="top"><p>DuplexMaker.py    --infile INFILE --outfile OUTFILE --Ncutoff NCUTOFF --readlength READ_LENGTH    --barcode_length BLENGTH [--read_out ROUT]</p></td>
+    <td width="516" colspan="8" valign="top"><p>DuplexMaker.py    --infile INFILE --outfile OUTFILE --Ncutoff NCUTOFF --readlength READ_LENGTH    --barcode_length BLENGTH [--read_out ROUT] [--gzip-fqs]</p></td>
   </tr>
   <tr>
     <td width="583" colspan="9" valign="top"><p><em>Required arguments:</em></p></td>
@@ -440,7 +445,7 @@
   <tr>
     <td width="67" valign="top"><p>&nbsp;</p></td>
     <td width="126" valign="top"><p>--outfile </p></td>
-    <td width="390" colspan="7" valign="top"><p>Output    .bam file.</p></td>
+    <td width="390" colspan="7" valign="top"><p>Output    output file name prefix (output FASTQS will be prefix.r1.fq and prefix.r2.fq).</p></td>
   </tr>
   <tr>
     <td width="67" valign="top"><p>&nbsp;</p></td>
@@ -496,6 +501,11 @@
     <td width="67" valign="top"><p>&nbsp;</p></td>
     <td width="126" valign="top"><p>--read_out</p></td>
     <td width="390" colspan="7" valign="top"><p>How    often you want to be told what the program is doing. Defaults to    1000000.&nbsp; In most cases, this is higher    than the number of SSCS reads.&nbsp; </p></td>
+  </tr>
+  <tr>
+    <td width="67" valign="top"><p>&nbsp;</p></td>
+    <td width="126" valign="top"><p>--gzip-fqs</p></td>
+	<td width="390" colspan="7" valign="top"><p>Output gzipped fastqs (.gz will be added to the output FASTQs).&nbsp; </p></td>
   </tr>
   <tr>
     <td width="583" colspan="9" valign="top"><p><strong><u>CountMuts.py</u></strong></p></td>

--- a/bash_template.sh
+++ b/bash_template.sh
@@ -128,7 +128,7 @@ samtools view -bu ${runIdentifier}.sscs.bam | samtools sort - ${runIdentifier}.s
 echo "Starting Duplex Maker" | tee -a ${logFile}
 date  | tee -a ${logFile}
 
-python ${DSpath}/DuplexMaker.py --infile ${runIdentifier}.sscs.sort.bam --outfile ${runIdentifier}.dcs.bam --Ncutoff $nCutOff --readlength $readLength
+python ${DSpath}/DuplexMaker.py --infile ${runIdentifier}.sscs.sort.bam --outfile ${runIdentifier}.dcs --Ncutoff $nCutOff --readlength $readLength
 
 # Step 8: Align DCSs
 echo "Aligning DCSs" | tee -a ${logFile}


### PR DESCRIPTION
- Remove output BAM from DuplexMaker and fixing up Docs.
- Ensure read names are unique across DCSs.
- Read name collisions are possible, although unlikely, across DCSs.
  This can occur when two DCSs with the same Duplex Tags are found; their
  respective SSCSs and raw reads map to different genomic locations.
- Fixing up duplex barcode collisions. See: https://github.com/loeblab/Duplex-Sequencing/issues/33
