### PR TITLE
Nh duplex maker read order

### DIFF
--- a/DuplexMaker.py
+++ b/DuplexMaker.py
@@ -140,10 +140,10 @@ def main():
             dictKeys = readDict.keys()
             
             for dictTag in readDict.keys(): # Extract sequences to send to the DCSmaker
-                switchtag = dictTag[o.blength:]+dictTag[:o.blength]
+                switchTag = dictTag[o.blength:]+dictTag[:o.blength]
                 
                 try:
-                    consensus = DSCMaker( [readDict[dictTag][6], readDict[switchtag][6]],  o.read_length )
+                    consensus = DSCMaker( [readDict[dictTag][6], readDict[switchTag][6]],  o.read_length )
                     duplexMade += 1
                     # Filter out consensuses with too many Ns in them
                     if consensus.count("N")/ len(consensus) > o.Ncutoff:
@@ -168,24 +168,27 @@ def main():
                         a.mpos=readDict[dictTag][4]
                         a.isize = readDict[dictTag][5]
                         a.qual = qualScore
-                        
-            # Write SSCSs to output BAM file in read pairs.
+                        consTag = None 
                         if dictTag in consensusDict:
+                            consTag = dictTag
+                        elif switchTag in consensusDict:
+                            consTag = switchTag  
+                        if consTag != None:
                             if a.is_read1 == True:
                                 fastqFile1.write('@:%s\n%s\n+\n%s\n' %(a.qname, a.seq, a.qual))
                                 outBam.write(a)
-                                fastqFile2.write('@:%s\n%s\n+\n%s\n' %(consensusDict[dictTag].qname, consensusDict[dictTag].seq, consensusDict[dictTag].qual))
-                                outBam.write(consensusDict.pop(dictTag))
+                                fastqFile2.write('@:%s\n%s\n+\n%s\n' %(consensusDict[consTag].qname, consensusDict[consTag].seq, consensusDict[consTag].qual))
+                                outBam.write(consensusDict.pop(consTag))
                             else:
-                                fastqFile1.write('@:%s\n%s\n+\n%s\n' %(consensusDict[dictTag].qname, consensusDict[dictTag].seq, consensusDict[dictTag].qual))
-                                outBam.write(consensusDict.pop(dictTag))
+                                fastqFile1.write('@:%s\n%s\n+\n%s\n' %(consensusDict[consTag].qname, consensusDict[consTag].seq, consensusDict[consTag].qual))
+                                outBam.write(consensusDict.pop(consTag))
                                 fastqFile2.write('@:%s\n%s\n+\n%s\n' %(a.qname, a.seq, a.qual))
                                 outBam.write(a)
                         else:
                             consensusDict[dictTag]=a
 
                     del readDict[dictTag]
-                    del readDict[switchtag]
+                    del readDict[switchTag]
                 
                 except:
                     pass

--- a/DuplexMaker.py
+++ b/DuplexMaker.py
@@ -135,7 +135,7 @@ def main():
         else:
             # Send reads to DCSMaker
             firstRead = line # Store the present line for the next group of lines
-            firstTag = firstRead.qname
+            firstTag = firstRead.qname.split(":")[0]
             readOne=True
             dictKeys = readDict.keys()
             


### PR DESCRIPTION
## DuplexMaker Issue

We expect that the following data should in both cases produce a single paired end double-strand consensus read.
### Example 1

```
ATGTTAAATTCATTAACGTCAGGG:1:5    99  chr1    24611538    255 84M =   24611796    342 AACTGAGGAGTAGGCGATTAGTGATTTTAAATCTGTTTGGCGTAAGCAGATTGAGCTAGTTATAATTATTCCTCATAGGGAGAG    JJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJ
TTAACGTCAGGGATGTTAAATTCA:2:4    163 chr1    24611538    255 84M =   24611796    342 AACTGAGGAGTAGGCGATTAGTGATTTTAAATCTGTTTGGCGTAAGCAGATTGAGCTAGTTATAATTATTCCTCATAGGGAGAG    JJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJ
TTAACGTCAGGGATGTTAAATTCA:1:4    83  chr1    24611796    255 84M =   24611538    -342    AATAAGAAATGCTATTATGCATGCCAACCATAGTAAGTTGTTAGATCATGAAGCGTCTAAGGTGTGTGTTGTGAATAATAAAAT    JJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJ
ATGTTAAATTCATTAACGTCAGGG:2:6    147 chr1    24611796    255 84M =   24611538    -342    AATAAGAAATGCTATTATGCATGCCAACCATAGTAAGTTGTTAGATCATGAAGCGTCTAAGGTGTGTGTTGTGAATAATAAAAT    JJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJ
```
### Example 2

```
ATGTTAAATTCATTAACGTCAGGG:1:5    99  chr1    24611538    255 84M =   24611796    342 AACTGAGGAGTAGGCGATTAGTGATTTTAAATCTGTTTGGCGTAAGCAGATTGAGCTAGTTATAATTATTCCTCATAGGGAGAG    JJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJ
TTAACGTCAGGGATGTTAAATTCA:2:4    163 chr1    24611538    255 84M =   24611796    342 AACTGAGGAGTAGGCGATTAGTGATTTTAAATCTGTTTGGCGTAAGCAGATTGAGCTAGTTATAATTATTCCTCATAGGGAGAG    JJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJ
ATGTTAAATTCATTAACGTCAGGG:2:6    147 chr1    24611796    255 84M =   24611538    -342    AATAAGAAATGCTATTATGCATGCCAACCATAGTAAGTTGTTAGATCATGAAGCGTCTAAGGTGTGTGTTGTGAATAATAAAAT    JJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJ
TTAACGTCAGGGATGTTAAATTCA:1:4    83  chr1    24611796    255 84M =   24611538    -342    AATAAGAAATGCTATTATGCATGCCAACCATAGTAAGTTGTTAGATCATGAAGCGTCTAAGGTGTGTGTTGTGAATAATAAAAT    JJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJ
```
## Commit: master

In both examples, a single unpaired double-strand consensus read is produced.
### Example 1

```
Summary Statistics: 
Reads Processed: 4
Duplexes Made: 1
Unpaired Duplexes: 1
N-clipped Duplexes: 0
--
r1.fq:@:ATGTTAAATTCATTAACGTCAGGG
r1.fq-AACTGAGGAGTAGGCGATTAGTGATTTTAAATCTGTTTGGCGTAAGCAGATTGAGCTAGTTATAATTATTCCTCATAGGGAGAG
r1.fq-+
r1.fq-JJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJ
--
r2.fq:@:ATGTTAAATTCATTAACGTCAGGG
r2.fq-....................................................................................
r2.fq-+
r2.fq-JJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJ
```

Why is the second end missing?
### Example 2

```
Summary Statistics: 
Reads Processed: 4
Duplexes Made: 1
Unpaired Duplexes: 1
N-clipped Duplexes: 0
--
r1.fq:@:ATGTTAAATTCATTAACGTCAGGG
r1.fq-AACTGAGGAGTAGGCGATTAGTGATTTTAAATCTGTTTGGCGTAAGCAGATTGAGCTAGTTATAATTATTCCTCATAGGGAGAG
r1.fq-+
r1.fq-JJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJ
--
r2.fq:@:ATGTTAAATTCATTAACGTCAGGG
r2.fq-....................................................................................
r2.fq-+
r2.fq-JJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJ
```

Why is the second end missing?
## Commit: e77df7933d07076e14a62244bf16b9576472dce9

Fixes parsing of the read name (`firstTag` is wrong after).
In the first example, a single unpaired double-strand consensus read is produced.  
In the second example, a single paired end double-strand consensus read is produced.
### Example 1

```
Summary Statistics: 
Reads Processed: 4
Duplexes Made: 2
Unpaired Duplexes: 2
N-clipped Duplexes: 0
--
r1.fq:@:ATGTTAAATTCATTAACGTCAGGG
r1.fq-AACTGAGGAGTAGGCGATTAGTGATTTTAAATCTGTTTGGCGTAAGCAGATTGAGCTAGTTATAATTATTCCTCATAGGGAGAG
r1.fq-+
r1.fq-JJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJ
r1.fq:@:TTAACGTCAGGGATGTTAAATTCA
r1.fq-ATTTTATTATTCACAACACACACCTTAGACGCTTCATGATCTAACAACTTACTATGGTTGGCATGCATAATAGCATTTCTTATT
r1.fq-+
r1.fq-JJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJ
--
r2.fq:@:ATGTTAAATTCATTAACGTCAGGG
r2.fq-....................................................................................
r2.fq-+
r2.fq-JJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJ
r2.fq:@:TTAACGTCAGGGATGTTAAATTCA
r2.fq-....................................................................................
r2.fq-+
r2.fq-JJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJ
```

Now we have two unpaired reads!
### Example 2

```
Summary Statistics: 
Reads Processed: 4
Duplexes Made: 2
Unpaired Duplexes: 0
N-clipped Duplexes: 0
--
r1.fq:@:ATGTTAAATTCATTAACGTCAGGG
r1.fq-AACTGAGGAGTAGGCGATTAGTGATTTTAAATCTGTTTGGCGTAAGCAGATTGAGCTAGTTATAATTATTCCTCATAGGGAGAG
r1.fq-+
r1.fq-JJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJ
--
r2.fq:@:ATGTTAAATTCATTAACGTCAGGG
r2.fq-ATTTTATTATTCACAACACACACCTTAGACGCTTCATGATCTAACAACTTACTATGGTTGGCATGCATAATAGCATTTCTTATT
r2.fq-+
r2.fq-JJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJ
```

We have a single paired end double-strand consensus read.  But example 1 is wrong.
## Commit: cd3a88f99c866be9ec250ff50313db1d80e6bfc0

Fixes issue with read name ordering for reads at the same position and across duplexes.

In both examples, a single paired end double-strand consensus read is produced.
### Example 1

```
Summary Statistics: 
Reads Processed: 4
Duplexes Made: 2
Unpaired Duplexes: 0
N-clipped Duplexes: 0
--
r1.fq:@:TTAACGTCAGGGATGTTAAATTCA
r1.fq-ATTTTATTATTCACAACACACACCTTAGACGCTTCATGATCTAACAACTTACTATGGTTGGCATGCATAATAGCATTTCTTATT
r1.fq-+
r1.fq-JJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJ
--
r2.fq:@:ATGTTAAATTCATTAACGTCAGGG
r2.fq-AACTGAGGAGTAGGCGATTAGTGATTTTAAATCTGTTTGGCGTAAGCAGATTGAGCTAGTTATAATTATTCCTCATAGGGAGAG
r2.fq-+
r2.fq-JJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJ
```

We have a single paired end double-strand consensus read as desired.
### Example 2

```
Summary Statistics: 
Reads Processed: 4
Duplexes Made: 2
Unpaired Duplexes: 0
N-clipped Duplexes: 0
--
r1.fq:@:ATGTTAAATTCATTAACGTCAGGG
r1.fq-AACTGAGGAGTAGGCGATTAGTGATTTTAAATCTGTTTGGCGTAAGCAGATTGAGCTAGTTATAATTATTCCTCATAGGGAGAG
r1.fq-+
r1.fq-JJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJ
--
r2.fq:@:ATGTTAAATTCATTAACGTCAGGG
r2.fq-ATTTTATTATTCACAACACACACCTTAGACGCTTCATGATCTAACAACTTACTATGGTTGGCATGCATAATAGCATTTCTTATT
r2.fq-+
r2.fq-JJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJ
```

We have a single paired end double-strand consensus read as desired.
